### PR TITLE
FIX: phing not reporting when exec steps fail

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -22,10 +22,10 @@
 			<if>
 				<not><available file="composer.phar" /></not>
 				<then>
-					<exec command="curl -s https://getcomposer.org/installer | php" passthru="true" />
+					<exec command="curl -s https://getcomposer.org/installer | php" passthru="true" checkreturn="true" />
 				</then>
 			</if>
-			<exec command="php composer.phar install ${composer.dev} --prefer-source" passthru="true" />
+			<exec command="php composer.phar install ${composer.dev} --prefer-source" passthru="true" checkreturn="true" />
 		</then>
 	</if>
 	<import file="${project.basedir}/build/buildfile.xml"/>
@@ -34,16 +34,16 @@
 		<if>
 			<not><available file="composer.phar" /></not>
 			<then>
-				<exec command="curl -s https://getcomposer.org/installer | php" passthru="true" />
+				<exec command="curl -s https://getcomposer.org/installer | php" passthru="true" checkreturn="true" />
 			</then>
 		</if>
 	</target>
 	
 	<target name="composer-install" depends="get-composer">
-		<exec command="php composer.phar install ${composer.dev} --prefer-source" passthru="true" />
+		<exec command="php composer.phar install ${composer.dev} --prefer-source" passthru="true" checkreturn="true" />
 	</target>
 	
 	<target name="composer-update" depends="get-composer">
-		<exec command="php composer.phar update ${composer.dev} --prefer-source" passthru="true" />
+		<exec command="php composer.phar update ${composer.dev} --prefer-source" passthru="true" checkreturn="true" />
 	</target>
 </project>


### PR DESCRIPTION
Enabled checkreturn flag on all exec commands to make builds fail if there are errors during exec (non-zero return code).