### PR TITLE
Performance improvements for build.xml template

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1,15 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!-- Rename this project to something relevant! -->
 <project name="rename-me" default="build">
+	<property name="composer.dev" value="" />
+	<property name="composer.source" value="--prefer-source" />
 	<if>
 		<isset property="ni_build" />
 		<then>
-			<property name="composer.dev" value="--no-dev" />
+			<property name="composer.dev" value="--no-dev" override="true" />
+			<property name="composer.source" value="--prefer-dist" override="true" />
 		</then>
-		<else>
-			<property name="composer.dev" value="" />
-		</else>
+	</if>
+	<if>
+		<isset property="composer_dist" />
+		<then>
+			<property name="composer.source" value="--prefer-dist" override="true" />
+		</then>
 	</if>
 	<if>
 		<not>
@@ -25,7 +30,7 @@
 					<exec command="curl -s https://getcomposer.org/installer | php" passthru="true" checkreturn="true" />
 				</then>
 			</if>
-			<exec command="php composer.phar install ${composer.dev} --prefer-source" passthru="true" checkreturn="true" />
+			<exec command="php composer.phar install ${composer.dev} ${composer.source}" passthru="true" checkreturn="true" />
 		</then>
 	</if>
 	<import file="${project.basedir}/build/buildfile.xml"/>
@@ -40,10 +45,10 @@
 	</target>
 	
 	<target name="composer-install" depends="get-composer">
-		<exec command="php composer.phar install ${composer.dev} --prefer-source" passthru="true" checkreturn="true" />
+		<exec command="php composer.phar install ${composer.dev} ${composer.source}" passthru="true" checkreturn="true" />
 	</target>
 	
 	<target name="composer-update" depends="get-composer">
-		<exec command="php composer.phar update ${composer.dev} --prefer-source" passthru="true" checkreturn="true" />
+		<exec command="php composer.phar update ${composer.dev} ${composer.source}" passthru="true" checkreturn="true" />
 	</target>
 </project>

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
 	"description": "Ozzy: the SilverStripe Australia project installer",
 	"require": {
 		"php": ">=5.3.2",
-		"silverstripe-australia/build": "~1.0",
+		"silverstripe-australia/build": "~2.0",
 		"silverstripe/cms": "~3.5@stable",
 		"silverstripe/framework": "~3.5@stable",
 		"silverstripe-themes/simple": "*",
@@ -17,7 +17,7 @@
 	},
 	"extra": {
 		"branch-alias": {
-			"dev-master": "3.0.x-dev"
+			"dev-master": "3.1.x-dev"
 		}
 	},
 	"minimum-stability": "dev"


### PR DESCRIPTION
New composer.source property to allow overriding composer's --prefer-source default option to be --prefer-dist (download dists instead of clone repos)
Allows passing -Dcomposer_dist=True to phing. This will be used as default in our CI environment but optional for local development.
Bump version to 2.x.